### PR TITLE
[READY] Shell out to git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,27 +2,14 @@ FROM golang:1.3
 MAINTAINER Steven Jack <stevenmajack@gmail.com>
 
 RUN apt-get update
-RUN apt-get install cmake pkg-config git -y
+RUN apt-get install git -y
 
-WORKDIR /usr/src/go/src
-RUN GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 ./make.bash --no-clean || true
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 ./make.bash --no-clean || true
-
-WORKDIR /go
-
-RUN go get -d github.com/libgit2/git2go
-WORKDIR $GOPATH/src/github.com/libgit2/git2go
-
-RUN git checkout next
-RUN git submodule update --init
-RUN make install
-RUN go install
+RUN go get github.com/mitchellh/gox
+RUN gox -build-toolchain
 
 RUN go get github.com/codegangsta/cli
 RUN go get gopkg.in/yaml.v2
 RUN go get github.com/fatih/color
-#RUN go get github.com/mitchellh/gox
-
-#RUN gox -build-toolchain
+RUN go get github.com/mitchellh/go-homedir
 
 WORKDIR /go

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.3
 MAINTAINER Steven Jack <stevenmajack@gmail.com>
 
 RUN apt-get update
-RUN apt-get install cmake pkg-config -y
+RUN apt-get install cmake pkg-config git -y
 
 WORKDIR /usr/src/go/src
 RUN GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 ./make.bash --no-clean || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,8 @@ RUN go install
 RUN go get github.com/codegangsta/cli
 RUN go get gopkg.in/yaml.v2
 RUN go get github.com/fatih/color
+#RUN go get github.com/mitchellh/gox
+
+#RUN gox -build-toolchain
 
 WORKDIR /go

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
-# cig
-Can I go? Checks all your git repos specified in a local config and gives a 
-report back of what state their in.
+<h1 align="center">cig</h1>
+
+<p align="center">
+  <a href="https://registry.hub.docker.com/u/smaj/cig" target="_blank"><img src="https://img.shields.io/badge/Docker-Hub-3a9bdc.svg?style=flat-square"></a>
+  </p>
+
+<p align="center">
+	Can I go? CLI app for checking the state of your git repositories.
+</p>
 
 ## Setup
 
 First create the following yaml file in your home directory:
 
-> ~/cig.yaml
+> ~/.cig.yaml
 
 ```yaml
 work: /path/to/work/repos
@@ -24,7 +30,7 @@ Simply run:
 and all repos will be checked and the following will show up:
 
 * Repos that need pushing up to the origin
-* Repos that have changes that haven't been commited
+* Repos that have new, unstaged and staged changes.
 
 To only check for a certain sub set of repos, say for example if you're at work
 just put the key from the yaml file as the second param:

--- a/cig.go
+++ b/cig.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"os/user"
 	"regexp"
 	"sync"
@@ -75,6 +76,24 @@ func checkRepo(path string, channel chan string, wg *sync.WaitGroup) {
 	opts.Show = git.StatusShowIndexAndWorkdir
 	opts.Flags = git.StatusOptIncludeUntracked | git.StatusOptRenamesHeadToIndex | git.StatusOptSortCaseSensitively
 
+	var count = "1"
+	exists, err := exists(fmt.Sprintf("%v/.git"))
+
+	if exists {
+
+		cmd := exec.Command("git ls-files | wc -l")
+		stdout, err := cmd.Output()
+
+		if err != nil {
+			println(err.Error())
+			return
+		}
+
+		count = int(stdout)
+
+		fmt.Sprintf("Count is: %v", count)
+	}
+
 	if err == nil {
 		statusList, err := repo.StatusList(opts)
 		check(err)
@@ -108,4 +127,15 @@ func checkRepo(path string, channel chan string, wg *sync.WaitGroup) {
 		}
 	}
 	wg.Done()
+}
+
+func exists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }

--- a/cig.go
+++ b/cig.go
@@ -29,7 +29,7 @@ func main() {
 	app.Action = func(c *cli.Context) {
 		paths := make(map[interface{}]interface{})
 		home_dir, err := homedir.Dir()
-		path := fmt.Sprintf("%s/cig.yaml", home_dir)
+		path := fmt.Sprintf("%s/.cig.yaml", home_dir)
 
 		data, err := ioutil.ReadFile(path)
 		check(err)

--- a/cig.go
+++ b/cig.go
@@ -13,6 +13,7 @@ import (
 	"os/user"
 	"regexp"
 	"sync"
+  "strings"
 )
 
 func check(e error) {
@@ -76,22 +77,23 @@ func checkRepo(path string, channel chan string, wg *sync.WaitGroup) {
 	opts.Show = git.StatusShowIndexAndWorkdir
 	opts.Flags = git.StatusOptIncludeUntracked | git.StatusOptRenamesHeadToIndex | git.StatusOptSortCaseSensitively
 
-	var count = "1"
-	exists, err := exists(fmt.Sprintf("%v/.git"))
+	exists, err := exists(fmt.Sprintf("%v/.git", path))
 
 	if exists {
 
-		cmd := exec.Command("git ls-files | wc -l")
-		stdout, err := cmd.Output()
+		modified_files := exec.Command("git", "ls-files")
+    modified_files.Dir = path
+
+		stdout, err := modified_files.Output()
 
 		if err != nil {
 			println(err.Error())
 			return
 		}
 
-		count = int(stdout)
+    split_strings := strings.Split(fmt.Sprintf("%s", stdout), "\n")
 
-		fmt.Sprintf("Count is: %v", count)
+    channel <- fmt.Sprintf("Modified files: %s\n", split_strings)
 	}
 
 	if err == nil {

--- a/cig.yaml
+++ b/cig.yaml
@@ -1,0 +1,1 @@
+personal: /projects/Personal

--- a/cig.yaml
+++ b/cig.yaml
@@ -1,1 +1,0 @@
-personal: /projects/Personal


### PR DESCRIPTION
### Problem

The `git2go` library works well until you want to cross compile it. The functionality of this app is pretty straight forward and the complexity of this library isn't really needed.
### Solution

Remove `git2go` and just shell out to the standard git binary.
