### PR TITLE
[READY] Adds travis yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+script:
+  - ./build/ci.sh
+deploy:
+  provider: releases
+  api_key:
+    secure: doUo3FJLvbkPrwadQKp6EqwU2D7/yhAdXmDXhBBEFC8uIoo99C1CN/97ajkTf7GW53ZUOACTsAPaEiE2d3MVBheFN4Rza+8QXqHXOOoLl/7NjP/Tm/BYFlIqFuYgGbDy3HPU2cAqSwwXPKhMByZ1ydsw7bazQfH3KuXTcTLs6to=
+  file:
+    - cig_darwin_x86_64
+    - cig_linux_x86_64
+    - cig_windows_x86_64.exe
+  skip_cleanup: true
+  on:
+    tags: true
+notifications:
+  email:
+    recipients:
+      - stevenmajack@gmail.com
+    on_failure: change
+    on_success: never
+
+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ curl -L https://bit.ly/cig-install | sudo bash
 ##### Manual install
 
 ```bash
-curl -L https://github.com/stevenjack/cig/releases/download/v0.1.1/cig_`uname -s`_`uname -m` > /usr/local/bin/cig
+curl -L https://github.com/stevenjack/cig/releases/download/v0.1.1/cig_`uname -s`_x86_64 > /usr/local/bin/cig
 chmod +x /usr/local/bin/cig
 ```
 
@@ -43,7 +43,6 @@ chmod +x /usr/local/bin/cig
 
 Download the following binary:
 
-* [32bit](https://github.com/stevenjack/cig/releases/download/v0.1.1/cig_windows_386.exe)
 * [64bit](https://github.com/stevenjack/cig/releases/download/v0.1.1/cig_windows_amd64.exe)
 
 Once you have the binary, run it via your cmd prompt:

--- a/build/ci.sh
+++ b/build/ci.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ $TRAVIS_BRANCH == 'master' ]]; then
+  go get github.com/mitchellh/gox
+  gox -os="darwin linux windows" -arch="amd64" -build-toolchain
+  gox -os="darwin linux windows" -arch="amd64" -output="{{.Dir}}_{{.OS}}_x86_64"
+else
+  go test
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-curl -L https://github.com/stevenjack/cig/releases/download/v0.1.1/cig_`uname -s`_`uname -m` > /usr/local/bin/cig
+curl -L https://github.com/stevenjack/cig/releases/download/v0.1.1/cig_`uname -s`_x86_64 > /usr/local/bin/cig
 chmod +x /usr/local/bin/cig


### PR DESCRIPTION
- Adds `.travis.yml`, that runs `go test` on each commit and creates a release when a tag is applied.
- Only provide three 64bit binaries (Linux, Windows and OS X)
