### PR TITLE
[READY] Uses filepath.Join

### DIFF
--- a/cig.go
+++ b/cig.go
@@ -42,7 +42,7 @@ func main() {
 
 		paths := make(map[interface{}]interface{})
 		home_dir, err := homedir.Dir()
-		path := fmt.Sprintf("%s%s.cig.yaml", home_dir, string(os.PathSeparator))
+		path := filepath.Join(home_dir, ".cig.yaml")
 
 		data, err := ioutil.ReadFile(path)
 

--- a/repo.go
+++ b/repo.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 )
 
 func checkRepo(root string, path string, channel chan string, wg *sync.WaitGroup) {
-	exists, err := exists(fmt.Sprintf("%s%s.git", path, string(os.PathSeparator)))
+	exists, err := exists(filepath.Join(path, ".git"))
 
 	if exists {
 		modified_files := exec.Command("git", "status", "-s")


### PR DESCRIPTION
Uses `filepath.Join` over manually concatenating string and using `os.PathSeparator`.
