### PR TITLE
[READY] Uses --porcelain over -s

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -14,7 +14,7 @@ func checkRepo(root string, path string, channel chan string, wg *sync.WaitGroup
 	exists, err := exists(filepath.Join(path, ".git"))
 
 	if exists {
-		modified_files := exec.Command("git", "status", "-s")
+		modified_files := exec.Command("git", "status", "--porcelain")
 		modified_files.Dir = path
 
 		count_out, _ := modified_files.Output()


### PR DESCRIPTION
`--porcelain` is made to be machine readable and doesn't add colour highlighting or additional cruft in the output, seems better to use this over `-s`.
