### PR TITLE
[READY] Consolidate error output

### DIFF
--- a/cig.go
+++ b/cig.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/stevenjack/cig/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/stevenjack/cig/Godeps/_workspace/src/github.com/fatih/color"
 	"github.com/stevenjack/cig/Godeps/_workspace/src/github.com/mitchellh/go-homedir"
 	"github.com/stevenjack/cig/Godeps/_workspace/src/gopkg.in/yaml.v2"
 )
@@ -47,13 +46,14 @@ func main() {
 		data, err := ioutil.ReadFile(path)
 
 		if err != nil {
-			channel <- color.RedString(fmt.Sprintf("Can't find config '%s'\n", path))
+			channel <- error_output(fmt.Sprintf("Can't find config '%s'\n", path))
 			os.Exit(-1)
 		}
 
 		err = yaml.Unmarshal([]byte(data), &paths)
+
 		if err != nil {
-			channel <- color.RedString(fmt.Sprintf("Problem parsing '%s', please check documentation", path))
+			channel <- error_output(fmt.Sprintf("Problem parsing '%s', please check documentation", path))
 			os.Exit(-1)
 		}
 		check(err)

--- a/helpers.go
+++ b/helpers.go
@@ -14,6 +14,10 @@ func check(err error) {
 	}
 }
 
+func error_output(message string) string {
+	return print_output(message, "red")
+}
+
 func output(channel chan string) {
 	for {
 		entry := <-channel


### PR DESCRIPTION
- Uses `print_output` across the board.
- Convenience method for outputting errors.
