### PR TITLE
[READY] Adds homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,17 @@ If you have [go](http://golang.org/) installed and the bin folder added to your 
 $: go get github.com/stevenjack/cig
 ```
 
-#### OSX/Linux
+#### OSX
+
+Make sure you have [homebrew](https://www.github.com/homebrew/homebrew) installed, then run the
+following:
+
+`$: brew install cig`
+
+> Alternativly you can follow the install instructions for `Linux` below if you don't have or
+want to into homebrew.
+
+#### Linux
 
 ##### One line install
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ following:
 
 `$: brew install cig`
 
-> Alternativly you can follow the install instructions for `Linux` below if you don't have or
-want to into homebrew.
+> Alternatively you can follow the install instructions for `Linux` below if you don't have or
+want to install homebrew.
 
 #### Linux
 


### PR DESCRIPTION
- Updates readme for OS X to include `brew` section.

> This is dependent on: https://github.com/Homebrew/homebrew/pull/39321
