### PR TITLE
[READY] Only build if branch looks like release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -L https://bit.ly/cig-install | sudo bash
 ##### Manual install
 
 ```bash
-curl -L https://github.com/stevenjack/cig/releases/download/v0.1.1/cig_`uname -s`_x86_64 > /usr/local/bin/cig
+curl -L https://github.com/stevenjack/cig/releases/download/v0.1.2/cig_`uname -s`_x86_64 > /usr/local/bin/cig
 chmod +x /usr/local/bin/cig
 ```
 
@@ -44,7 +44,7 @@ chmod +x /usr/local/bin/cig
 
 Download the following binary:
 
-* [64bit](https://github.com/stevenjack/cig/releases/download/v0.1.1/cig_windows_amd64.exe)
+* [64bit](https://github.com/stevenjack/cig/releases/download/v0.1.2/cig_windows_amd64.exe)
 
 Once you have the binary, run it via your cmd prompt:
 

--- a/build/ci.sh
+++ b/build/ci.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [[ $TRAVIS_BRANCH == 'master' ]]; then
+go test
+
+if [[ $TRAVIS_BRANCH =~ "^v[0-9\.]+" ]]; then
   go get github.com/mitchellh/gox
   gox -os="darwin linux windows" -arch="amd64" -build-toolchain
   gox -os="darwin linux windows" -arch="amd64" -output="{{.Dir}}_{{.OS}}_x86_64"
-else
-  go test
 fi

--- a/cig.go
+++ b/cig.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stevenjack/cig/output"
 )
 
-const version string = "0.1.1"
+const version string = "0.1.2"
 
 func main() {
 	var output_channel = make(chan output.Payload)

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-curl -L https://github.com/stevenjack/cig/releases/download/v0.1.1/cig_`uname -s`_x86_64 > /usr/local/bin/cig
+curl -L https://github.com/stevenjack/cig/releases/download/v0.1.2/cig_`uname -s`_x86_64 > /usr/local/bin/cig
 chmod +x /usr/local/bin/cig


### PR DESCRIPTION
### Problem

The build and deploy works whenever a tag is pushed up (This is only done for releases). Issues is that the branch is being checked to see if it's master when intact it's the tag name.
### Solution

Use a regex to check if it's a version tag then run the build.

> Move the tests out of the if block as they should run regardless.
