### PR TITLE
Adds FatalError method to output

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -29,7 +29,7 @@ func Handle(repoList map[string]string, projectTypeToCheck string, filter string
 
 			err := filepath.Walk(path, visit)
 			if err != nil {
-				output_channel <- output.Error(err.Error())
+				output_channel <- output.FatalError(err.Error())
 			}
 		}
 

--- a/cig.go
+++ b/cig.go
@@ -23,7 +23,7 @@ func main() {
 		repo_list, err := app.Config(config_path)
 
 		if err != nil {
-			output_channel <- output.Error(err.Error())
+			output_channel <- output.FatalError(err.Error())
 		}
 
 		app.Handle(repo_list, project_type, filter, output_channel)

--- a/output/output.go
+++ b/output/output.go
@@ -11,10 +11,21 @@ import (
 type Payload struct {
 	Message string
 	Error   bool
+	Fatal   bool
 }
 
 func (p *Payload) IsError() {
 	p.Error = true
+}
+
+func (p *Payload) IsFatal() {
+	p.Fatal = true
+}
+
+func FatalError(message string) Payload {
+	payload := Error(message)
+	payload.IsFatal()
+	return payload
 }
 
 func Error(message string) Payload {
@@ -25,7 +36,7 @@ func Error(message string) Payload {
 }
 
 func Print(message string) Payload {
-	return Payload{message, false}
+	return Payload{message, false, false}
 }
 
 func ApplyColour(message string, outputType string) string {
@@ -45,7 +56,7 @@ func Wait(channel chan Payload) {
 	for {
 		entry := <-channel
 		fmt.Println(entry.Message)
-		if entry.Error {
+		if entry.Fatal {
 			os.Exit(-1)
 		}
 	}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -28,7 +28,7 @@ func Check(root string, path string, output_channel chan output.Payload, wg *syn
 		modified := len(modified_lines) - 1
 
 		if err != nil {
-			output_channel <- output.Error(err.Error())
+			output_channel <- output.FatalError(err.Error())
 		}
 
 		changes := []string{}


### PR DESCRIPTION
### Problem

Currently you could only output an error through the output channel and exit the application, sometimes you may want to output one and continue execution.
### Solution

Adds a `output.FatalError` method which exits the application, then `output.Error` can be called which will just output a red version of the message and continue.
