### PR TITLE
defer wg.Done() 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -33,7 +33,7 @@ func Handle(repoList map[string]string, projectTypeToCheck string, filter string
 
 			err := filepath.Walk(path, visit)
 			if err != nil {
-				output_channel <- output.FatalError(err.Error())
+				output_channel <- output.Error(err.Error())
 			}
 		}
 

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -13,6 +13,7 @@ import (
 )
 
 func Check(root string, path string, output_channel chan output.Payload, wg *sync.WaitGroup) {
+	defer wg.Done()
 	exists, err := Exists(filepath.Join(path, ".git"))
 
 	if err != nil {
@@ -69,7 +70,6 @@ func Check(root string, path string, output_channel chan output.Payload, wg *syn
 		}
 
 	}
-	wg.Done()
 }
 
 func Exists(path string) (bool, error) {


### PR DESCRIPTION
### Problem

When there's an issue `Check` function of the `repo` namespace it ends up bombing out and not finishing the wait group causing a deadlock on the go routines.
### Solution

`defer` the `wg.Done()` so it's always called at the end of the function run.
