### PR TITLE
If tilde exists replace with home directory path

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 
+	"github.com/stevenjack/cig/Godeps/_workspace/src/github.com/mitchellh/go-homedir"
 	"github.com/stevenjack/cig/output"
 	"github.com/stevenjack/cig/repo"
 )
@@ -17,6 +19,7 @@ func Handle(repoList map[string]string, projectTypeToCheck string, filter string
 	for projectType, path := range repoList {
 		if projectTypeToCheck == "" || projectTypeToCheck == projectType {
 			output_channel <- output.Print(fmt.Sprintf("\nChecking '%s' (%s) repos...", projectType, path))
+			path = resolvePath(path)
 
 			visit := func(visitedPath string, info os.FileInfo, err error) error {
 				if err != nil {
@@ -40,4 +43,15 @@ func Handle(repoList map[string]string, projectTypeToCheck string, filter string
 		wg.Wait()
 	}
 	wg.Wait()
+}
+
+func resolvePath(path string) string {
+	hasTilde := strings.HasPrefix(path, "~")
+	if hasTilde {
+		homeDir, err := homedir.Dir()
+		if err == nil {
+			return strings.Replace(path, "~", homeDir, -1)
+		}
+	}
+	return path
 }


### PR DESCRIPTION
### Problem

Currently CIG doesn't handle a `~` properly and can't resolve the path.
### Solution

Interpolate the `~` in a directory to the full home directory path for the current user.
